### PR TITLE
Update design matrix

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -175,8 +175,9 @@ Adding new points to the design matrix
 
 In some applications, you might want to augment the design matrix after a few iterations of PyePAL. This could be useful, for example, if you start with a coarse discretization of your design space then then want to refine this grid in subsequent iterations in the relevant regions of the design space.
 
-Adding new points to the design matrix can be easily achieved using the :py:func:`~pyepal.pal.pal_base.PALBase.augment_design_matrix` function that takes the new design matrix as input. By default, it will run the current model for the new, augmented, design matrix and classify the points that were just added to the design matrix. You can turn this behavior off using the :code:`classify` parameter.
+Adding new points to the design matrix can be easily achieved using the :py:func:`~pyepal.pal.pal_base.PALBase.augment_design_matrix` function that takes the new design matrix as input. By default, it will run the current model for the new, augmented, design matrix and re-classify all points. You can turn this behavior off using the :code:`clean_classify` parameter.
 
+Alternatively, you can use the :code:`classify` flag that keeps all previous classifications. This means that if there is a point that was perviously Pareto-efficient in the non-augmented design space, but is now augmented by a new design points, it will no longer certainly be classified as Pareto-efficient.
 
 Caveats and tricks with Gaussian processes
 -------------------------------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -179,6 +179,9 @@ Adding new points to the design matrix can be easily achieved using the :py:func
 
 Alternatively, you can use the :code:`classify` flag that keeps all previous classifications. This means that if there is a point that was perviously Pareto-efficient in the non-augmented design space, but is now augmented by a new design points, it will no longer certainly be classified as Pareto-efficient.
 
+Note that is important that the new points are sampled from the same distribution as the previous points in the design space. Otherwise the model will have to deal with unexpected datashift.
+
+
 Caveats and tricks with Gaussian processes
 -------------------------------------------
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -126,7 +126,7 @@ For debugging there are some properties and attributes of the `PAL` class that c
     - :code:`sampled_points`: returns the points that have been sampled
     - :code:`discarded_points`: returns the points that have been discarded
 - get the indices of Pareto efficent, sampled,  discarded, and unclassified points with :code:`pareto_optimal_indices`, :code:`sampled_indices`, :code:`discarded_indices`, and :code:`unclassified_indices`
-- similarly, the number of points in the different classes can be obtained using :code:`number_pareto_optimal_points`, :code:`number_discarded_points`, :code:`number_unclassified_points`, and :code:`number_sampled_points`
+- similarly, the number of points in the different classes can be obtained using :code:`number_pareto_optimal_points`, :code:`number_discarded_points`, :code:`number_unclassified_points`, and :code:`number_sampled_points`. The total number of design points can be obtained with :code:`number_design_points`.
 - :code:`hyperrectangle_size` returns the sizes of the hyperrectangles, i.e., the weights that are used in the sampling step
 - :code:`means` and :code:`std` contain the predictions of the model
 - :code:`sampled` is a mask array. In case one objective has not been measured its cell is :code:`False`
@@ -168,6 +168,15 @@ Note that the `exhaust_loop` also supports the `batch_size` keyword argument
     # sample always 10 points and do this until there is no unclassified
     # point left
     exhaust_loop(palinstance, y, batch_size=10)
+
+
+Adding new points to the design matrix
+........................................
+
+In some applications, you might want to augment the design matrix after a few iterations of PyePAL. This could be useful, for example, if you start with a coarse discretization of your design space then then want to refine this grid in subsequent iterations in the relevant regions of the design space.
+
+Adding new points to the design matrix can be easily achieved using the :py:func:`~pyepal.pal.pal_base.PALBase.augment_design_matrix` function that takes the new design matrix as input. By default, it will run the current model for the new, augmented, design matrix and classify the points that were just added to the design matrix. You can turn this behavior off using the :code:`classify` parameter.
+
 
 Caveats and tricks with Gaussian processes
 -------------------------------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -173,13 +173,13 @@ Note that the `exhaust_loop` also supports the `batch_size` keyword argument
 Adding new points to the design matrix
 ........................................
 
-In some applications, you might want to augment the design matrix after a few iterations of PyePAL. This could be useful, for example, if you start with a coarse discretization of your design space then then want to refine this grid in subsequent iterations in the relevant regions of the design space.
+In some applications, you might want to augment the design matrix after a few iterations of PyePAL. This could be useful, for example, if you start with a coarse discretization of your design space then want to refine this grid in subsequent iterations in the relevant regions of the design space.
 
-Adding new points to the design matrix can be easily achieved using the :py:func:`~pyepal.pal.pal_base.PALBase.augment_design_matrix` function that takes the new design matrix as input. By default, it will run the current model for the new, augmented, design matrix and re-classify all points. You can turn this behavior off using the :code:`clean_classify` parameter.
+Adding new points to the design matrix can be easily achieved using the :py:func:`~pyepal.pal.pal_base.PALBase.augment_design_matrix` function that takes the new design matrix as input. By default, it will run the current model for the new, augmented, design matrix, and re-classify all points. You can turn this behavior off using the :code:`clean_classify` parameter.
 
-Alternatively, you can use the :code:`classify` flag that keeps all previous classifications. This means that if there is a point that was perviously Pareto-efficient in the non-augmented design space, but is now augmented by a new design points, it will no longer certainly be classified as Pareto-efficient.
+Alternatively, you can use the :code:`classify` flag that keeps all previous classifications. This means that if there is a point that was previously Pareto-efficient in the non-augmented design space but is now dominated by a new design point, it will no longer certainly be classified as Pareto-efficient.
 
-Note that is important that the new points are sampled from the same distribution as the previous points in the design space. Otherwise the model will have to deal with unexpected datashift.
+Note that is important that the new points are sampled from the same distribution as the previous points in the design space. Otherwise, the model will have to deal with unexpected data shift.
 
 
 Caveats and tricks with Gaussian processes

--- a/pyepal/pal/pal_base.py
+++ b/pyepal/pal/pal_base.py
@@ -454,16 +454,20 @@ In the docs, you find hints on how to make GPRs more robust.""".format(
         self._turn_to_maximization()
 
     def augment_design_space(  # pylint: disable=invalid-name
-        self, X_design: np.ndarray, re_classify: bool = True
+        self, X_design: np.ndarray, classify: bool = True
     ) -> None:
         """Add new design points to PAL instance
 
         Args:
             X_design (np.ndarrary): Design matrix. Two-dimensional array containing
                 measurements in the rows and the features as the columns.
-            re_classify (bool): Reclassifies the new design space, using the old model.
+            classify (bool): Reclassifies the new design space, using the old model.
                 This is, it runs inference, calculates the hyperrectangles, and runs
                 the classification. Does not increase the iteration count.
+                Note though that points that already have been classified
+                as Pareto-optimal will not be re-classified,
+                e.g., discarded---even if the new design points
+                dominate the existing "Pareto optimal" points.
                 Defaults to True.
         """
 
@@ -536,7 +540,7 @@ In the docs, you find hints on how to make GPRs more robust.""".format(
         # Make sure that the new points have the same "state" as the old ones
         # This is, we can use the new design space in a proper way for sampling
         # or classification
-        if re_classify:
+        if classify:
             self._predict()
             self._replace_by_measurements()
             self._update_hyperrectangles()

--- a/pyepal/pal/utils.py
+++ b/pyepal/pal/utils.py
@@ -131,7 +131,7 @@ def exhaust_loop(
     Returns:
         None. The PAL instance is updated in place
     """
-    assert palinstance.design_space_size == len(
+    assert palinstance.number_design_points == len(
         y
     ), "The number of points in the design space must equal the number of measurements"
     while sum(palinstance.unclassified):

--- a/pyepal/plotting/__init__.py
+++ b/pyepal/plotting/__init__.py
@@ -119,7 +119,7 @@ def plot_pareto_front_2d(  # pylint:disable=too-many-arguments, invalid-name
         == len(y_1)
         == len(std_0)
         == len(std_1)
-        == palinstance.design_space_size
+        == palinstance.number_design_points
     ), "Make sure that the arrays have the same length"
 
     if ax is None:
@@ -185,7 +185,7 @@ def plot_histogram(
     assert isinstance(y, np.ndarray), "Input array y must be a numpy array"
     assert y.ndim == 1, "Input array y must be one dimensional"
     assert (
-        len(y) == palinstance.design_space_size
+        len(y) == palinstance.number_design_points
     ), "Length of y must equal the size of the design space"
 
     if ax is None:
@@ -250,7 +250,7 @@ def plot_residuals(  # pylint:disable=invalid-name
 
     assert isinstance(y, np.ndarray), "Input array y must be a numpy array"
     assert (
-        len(y) == palinstance.design_space_size
+        len(y) == palinstance.number_design_points
     ), "Length of y must equal the size of the design space"
     assert y.ndim == 2, "y must be a two-dimensional numpy array"
     assert (
@@ -317,7 +317,7 @@ def plot_jointplot(  # pylint:disable=invalid-name
     """
     assert isinstance(y, np.ndarray), "Input array y must be a numpy array"
     assert (
-        len(y) == palinstance.design_space_size
+        len(y) == palinstance.number_design_points
     ), "Length of y must equal the size of the design space"
     assert y.ndim == 2, "y must be a two-dimensional numpy array"
     assert (

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -36,6 +36,15 @@ def binh_korn_points():
 
 
 @pytest.fixture()
+def binh_korn_points_finer():
+    """Create a dataset based on the Binh-Korn test function"""
+    x = np.linspace(0, 5, 399)  # pylint:disable=invalid-name
+    y = np.linspace(0, 3, 399)  # pylint:disable=invalid-name
+    array = np.array([binh_korn(xi, yi) for xi, yi in zip(x, y)])
+    return np.hstack([x.reshape(-1, 1), y.reshape(-1, 1)]), array
+
+
+@pytest.fixture()
 def make_random_dataset(targets=3):
     """Make a dataset with three targets"""
     return make_regression(

--- a/tests/test_pal_base.py
+++ b/tests/test_pal_base.py
@@ -103,7 +103,7 @@ def test_augment_design_space(make_random_dataset):
     palinstance.unclassified = unclassified
 
     # As we do not have a model, we cannot test the classification
-    palinstance.augment_design_space(X_augmented, classify=False)
+    palinstance.augment_design_space(X_augmented, clean_classify=False)
     assert palinstance.number_discarded_points == 0
     assert palinstance.number_pareto_optimal_points == 2
     assert palinstance.number_unclassified_points == 298

--- a/tests/test_pal_base.py
+++ b/tests/test_pal_base.py
@@ -28,6 +28,7 @@ def test_pal_base(make_random_dataset):
     assert palinstance.number_pareto_optimal_points == 0
     assert palinstance.number_unclassified_points == 100
     assert palinstance.number_sampled_points == 0
+    assert palinstance.number_design_points == 100
     assert palinstance.should_cross_validate()
     assert len(palinstance.discarded_points) == 0
     assert len(palinstance.pareto_optimal_points) == 0
@@ -64,6 +65,52 @@ def test_update_train_set(make_random_dataset):
     assert palinstance.sampled_indices == np.array([0])
     assert palinstance.number_sampled_points == 1
     assert (palinstance.y[0] == y[0, :]).all()
+
+
+def test_augment_design_space(make_random_dataset):
+    """Testing the basic functionality of the augmentation method
+    Does NOT test the re-classification step, which needs a model"""
+    X, _ = make_random_dataset  # pylint: disable=invalid-name
+    X_augmented = np.vstack([X, X])  # pylint: disable=invalid-name
+    palinstance = PALBase(X, ["model"], 3)
+    # Iteration count to low
+    with pytest.raises(ValueError):
+        palinstance.augment_design_space(X_augmented)
+
+    palinstance.iteration = 2
+    # Incorrect shape
+    with pytest.raises(AssertionError):
+        palinstance.augment_design_space(X_augmented[:, 2])
+
+    with pytest.raises(ValueError):
+        palinstance.augment_design_space(X_augmented[:, :2])
+
+    #  Mock that we already ran that
+    lows = np.zeros((100, 3))
+    highs = np.zeros((100, 3))
+
+    means = np.full((100, 3), 1)
+    palinstance.means = means
+    palinstance.std = np.full((100, 3), 0.1)
+    pareto_optimal = np.array([False] * 98 + [True, True])
+    sampled = np.array([[False] * 3, [False] * 3, [False] * 3, [False] * 3])
+    unclassified = np.array([True] * 98 + [False, False])
+
+    palinstance.rectangle_lows = lows
+    palinstance.rectangle_ups = highs
+    palinstance.sampled = sampled
+    palinstance.pareto_optimal = pareto_optimal
+    palinstance.unclassified = unclassified
+
+    # As we do not have a model, we cannot test the classification
+    palinstance.augment_design_space(X_augmented, re_classify=False)
+    assert palinstance.number_discarded_points == 0
+    assert palinstance.number_pareto_optimal_points == 2
+    assert palinstance.number_unclassified_points == 298
+    assert palinstance.number_sampled_points == 0
+    assert palinstance.number_design_points == 300
+    assert len(palinstance.means) == 300
+    assert len(palinstance.std) == 300
 
 
 def test_beta_update(make_random_dataset):

--- a/tests/test_pal_base.py
+++ b/tests/test_pal_base.py
@@ -103,7 +103,7 @@ def test_augment_design_space(make_random_dataset):
     palinstance.unclassified = unclassified
 
     # As we do not have a model, we cannot test the classification
-    palinstance.augment_design_space(X_augmented, re_classify=False)
+    palinstance.augment_design_space(X_augmented, classify=False)
     assert palinstance.number_discarded_points == 0
     assert palinstance.number_pareto_optimal_points == 2
     assert palinstance.number_unclassified_points == 298


### PR DESCRIPTION
* by default, will classify all the points in the new design space WITHOUT increasing the iteration count
* should not be used for the first iteration (makes no sense there)
* maybe we should even raise a warning if re-classify is not used
* to increase efficiency, we might add indices argument for the _core method to run the updates only on the new points

This PR should be **squashed** before merging. 

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

The breaking part is that i removed the `design_space_size` attribute and replaced it with `number_design_points`. I replaced all places where we used `design_space_size`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation
- [ ] Developer tools
- [ ] Refactoring
- [ ] Test

## Actions (for code changes)

- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
