### PR TITLE
feat: added option to use fixed epsilon

### DIFF
--- a/docs/background.rst
+++ b/docs/background.rst
@@ -7,6 +7,8 @@ This implementation has the following features:
 
 - We ensure that the sampling is scale-invariant and that the algorithm can deal with positive and negative objective values.
 
+- In contrast to the `original implementation by Zuluaga et al. <https://jmlr.org/papers/v17/15-047.html>`_ we do not assume that the range of the objectives is known a priori. In their implementation it is used to calculate fixed tolerance values :math:`\epsilon_i \cdot r_i` (where :math:`r_i` is the range of objective :math:`i`). We instead use by default :math:`\epsilon_i \cdot |\mu_i|`.
+
 - Instead of using the predicted :math:`\hat{\mu}` and :math:`\hat{\sigma}` also for the sampled points we use the measured :math:`\mu` and :math:`\sigma`.
 
 - This implementation is directly scalable to :math:`n`-dimensional problems.

--- a/pyepal/pal/validate_inputs.py
+++ b/pyepal/pal/validate_inputs.py
@@ -18,7 +18,7 @@
 import collections
 import warnings
 from copy import deepcopy
-from typing import Any, Iterable, List, Sequence
+from typing import Any, Iterable, List, Sequence, Union
 
 import numpy as np
 from sklearn.gaussian_process import GaussianProcessRegressor
@@ -446,3 +446,20 @@ def validate_positive_integer_list(
             raise ValueError("{} must be a positive integer".format(parameter_name))
 
     return seq
+
+
+def validate_ranges(ranges: Any, ndim: int) -> Union[None, np.ndarray]:
+    """Make sure that it has the correct numnber of elements and that all
+    elements are positive."""
+    if not isinstance(ranges, (np.ndarray, list)):
+        return None
+
+    if not len(ranges) == ndim:
+        raise ValueError(
+            "The number of elements in ranges must match the number of objectives."
+        )
+    for elem in ranges:
+        if not elem > 0:
+            raise ValueError("Ranges must be positive.")
+
+    return np.array(ranges)

--- a/tests/test_pal_base.py
+++ b/tests/test_pal_base.py
@@ -52,6 +52,10 @@ def test_pal_base(make_random_dataset):
         palinstance.sample()
 
     assert palinstance.y.shape == (100, 3)
+    assert not palinstance.uses_fixed_epsilon
+
+    palinstance = PALBase(make_random_dataset[0], ["model"], 3, ranges=[1, 1, 1])
+    assert palinstance.uses_fixed_epsilon
 
 
 def test_update_train_set(make_random_dataset):

--- a/tests/test_pal_core.py
+++ b/tests/test_pal_core.py
@@ -273,6 +273,28 @@ def test_pareto_classify(binh_korn_points):  # pylint:disable=too-many-locals
         == np.array([False, False, False, False, False, False, False, True])
     ).all()
 
+    pareto_optimal_t, discarded_t, unclassified_t = _pareto_classify(
+        is_pareto_optimal,
+        is_discarded,
+        is_unclassified,
+        rectangle_lows,
+        rectangle_ups,
+        np.array([0.1, 0.1]),
+        is_fixed_epsilon=True,
+    )
+
+    assert (
+        pareto_optimal_t
+        == np.array([True, True, True, False, True, False, False, False])
+    ).all()
+    assert (
+        discarded_t == np.array([False, False, False, True, False, True, True, False])
+    ).all()
+    assert (
+        unclassified_t
+        == np.array([False, False, False, False, False, False, False, True])
+    ).all()
+
     # 3D arrays, but 3rd dimenension alsways 0
 
     pareto_optimal_points = np.array([[0.5, 2, 0], [3, 1, 0], [4, 0.5, 0]])

--- a/tests/test_validate_inputs.py
+++ b/tests/test_validate_inputs.py
@@ -41,6 +41,7 @@ from pyepal.pal.validate_inputs import (
     validate_number_models,
     validate_optimizers,
     validate_positive_integer_list,
+    validate_ranges,
 )
 
 
@@ -316,3 +317,18 @@ def test_validate_positive_integer_list():
         validate_positive_integer_list(-1, 2)
 
     assert validate_positive_integer_list(1, 2) == [1, 1]
+
+
+def test_validate_ranges():
+    """Check that the range validation works"""
+    arr = np.array([1, 1, 1])
+    assert (arr == validate_ranges(arr, 3)).all()
+
+    with pytest.raises(ValueError):
+        validate_ranges(arr, 2)
+
+    with pytest.raises(ValueError):
+        validate_ranges(np.array([-0.1, 0.1, 1]), 2)
+
+    assert validate_ranges(None, 3) is None
+    assert (validate_ranges([1, 1, 1], 3) == np.array([1, 1, 1])).all()


### PR DESCRIPTION
This is used in the Zuluaga et al. implementation. This requires that the range of the objectives is known *before* running the algorithm. We, by default, use epsilon * mu instead which avoids this problem. 

Adding this feature allows us to compare also this change w.r.t. to the original implementation. 

*Note*: When implementing the unit tests I observed that it tended to discard more points on the Binh-Korn dataset. 

- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Documentation
- [ ] Developer tools
- [ ] Refactoring
- [ ] Test

## Actions (for code changes)

- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
